### PR TITLE
Buffer overflow fix

### DIFF
--- a/src/usb_linux.c
+++ b/src/usb_linux.c
@@ -52,7 +52,7 @@ struct usb_handle
     usb_handle *prev;
     usb_handle *next;
 
-    char fname[64];
+    char fname[255];
     int desc;
     unsigned char ep_in;
     unsigned char ep_out;
@@ -139,7 +139,10 @@ static void find_usb_device(const char *base,
     int fd ;
 
     busdir = opendir(base);
-    if(busdir == 0) return;
+    if(busdir == 0) {
+        fprintf(stderr, "* ERROR OPENING BASE DIR: %s *\n", base);
+        return;
+    }
 
     while((de = readdir(busdir)) != 0) {
         if(badname(de->d_name)) continue;
@@ -692,16 +695,13 @@ void* device_poll_thread(void* unused)
 	char busname[255];
 	char* device_id = getenv("ANDROID_DEVICE_ID");
 	if (device_id && strlen(device_id) > 0) {
-		DIR* devdir = opendir("/devhost");
-		if(ENOENT == errno) {
-			snprintf(busname, sizeof busname, "/dev/testobject/%s", device_id);
-			find_usb_device(busname, register_device);
-		} else {
-			snprintf(busname, sizeof busname, "/devhost/testobject/%s", device_id);
-			find_usb_device(busname, register_device);
-			closedir(devdir);
-		} 
+		DIR* devdir = opendir("/dev");
+        snprintf(busname, sizeof busname, "/dev/testobject/%s", device_id);
+        fprintf(stdout,"* daemon connecting to device at /dev/testobject/%s *\n", device_id);
+        find_usb_device(busname, register_device);
+        closedir(devdir);
 	} else {
+        fprintf(stdout, "* daemon connecting to ALL Android devices * \n");
 		find_usb_device("/dev/bus/usb", register_device);
 	} 
 

--- a/src/usb_linux.c
+++ b/src/usb_linux.c
@@ -132,7 +132,7 @@ static void find_usb_device(const char *base,
         void (*register_device_callback)
                 (const char *, const char *, unsigned char, unsigned char, int, int, unsigned))
 {
-    char busname[128], devname[128];
+    char busname[255], devname[255];
     unsigned char local_ep_in, local_ep_out;
     DIR *busdir , *devdir ;
     struct dirent *de;


### PR DESCRIPTION
- Fixed the buffer overflow when a TestObject physical device ID ("ANDROID_DEVICE_ID") was too long
- Removed /devhost check; docker containers no longer use this folder
- Added a log line to indicate which device the ADB instance is looking for

Testing:
- Connected an Android device to my computer. `ln -s /dev/bus/usb/002/006 /dev/testobject/1234567890123456789012345678901234567890/001/001`, then `env ANDROID_DEVICE_ID=1234567890123456789012345678901234567890 ./adb devices`. Without the fix, a crash; with the fix, lists devices as expected.
